### PR TITLE
TECH: Change Span Type To Custom

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -44,7 +44,7 @@ defmodule SpandexEcto.EctoLogger do
         completion_time: now,
         service: service,
         resource: query,
-        type: :db,
+        type: :custom,
         sql_query: [
           query: query,
           rows: inspect(num_rows),


### PR DESCRIPTION
Datadog does not enable it's Deployment Tracking features for APM's with spans of a `type: :db` .  Changing it to `type: :custom` allows it to do its deployment tracking features.  