### PR TITLE
TECH-266:  Change Span Type to Custom

### DIFF
--- a/lib/spandex_ecto/ecto_logger.ex
+++ b/lib/spandex_ecto/ecto_logger.ex
@@ -40,7 +40,7 @@ defmodule SpandexEcto.EctoLogger do
         completion_time: now,
         service: service,
         resource: query,
-        type: :db,
+        type: :custom,
         sql_query: [
           query: query,
           rows: inspect(num_rows),


### PR DESCRIPTION
DataDog does not support / enable APM Deployment Tracking for database type Spans, changing the type to custom allows it to work.